### PR TITLE
bugfix: could not convert string to float

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,6 @@ from healthcheck import HealthCheck, EnvironmentDump
 from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client.metrics_core import (
     GaugeMetricFamily,
-    InfoMetricFamily,
 )
 
 config = {
@@ -88,9 +87,7 @@ class YandexCloudCollectorAll(CollectorRegistry):
         for service in get_yc_status:
             if service["incidents"]:
                 for incident in service["incidents"]:
-                    if not incident.get("endDate"):
-                        pass
-                    else:
+                    if incident.get("endDate"):
                         end_date = incident.get("endDate")
                         last_incidents.add_metric(
                             labels=[

--- a/app.py
+++ b/app.py
@@ -70,7 +70,7 @@ class YandexCloudCollectorAll(CollectorRegistry):
             "Yandex Cloud Active Incidents",
             labels=["id", "product", "comments", "last_update", "type"],
         )
-        last_incidents = InfoMetricFamily(
+        last_incidents = GaugeMetricFamily(
             "yc_last_incidents",
             "Yandex Cloud Services last incidents",
             labels=["service_name", "end_date"],
@@ -88,13 +88,17 @@ class YandexCloudCollectorAll(CollectorRegistry):
         for service in get_yc_status:
             if service["incidents"]:
                 for incident in service["incidents"]:
-                    last_incidents.add_metric(
-                        labels=[
-                            service["slug"].replace("-", "_"),
-                            incident.get("endDate"),
-                        ],
-                        value={"title": incident.get("title")},
-                    )
+                    if not incident.get("endDate"):
+                        pass
+                    else:
+                        end_date = incident.get("endDate")
+                        last_incidents.add_metric(
+                            labels=[
+                                service["slug"].replace("-", "_"),
+                                end_date,
+                            ],
+                            value=incident.get("title"),
+                        )
 
                     incident_severity = self.severity_handler(incident)
                     if incident_severity == 0:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -16,8 +16,8 @@ def test_metrics():
     response = cache.app.test_client().get("/metrics")
     assert response.status_code == 200
     assert b"yc_service_status" in response.data
-    assert b"yc_last_incidents_info" in response.data
-    assert b"# HELP yc_active_incidents" in response.data
+    assert b"yc_last_incidents" in response.data
+    assert b"yc_active_incidents" in response.data
 
 
 def test_healthcheck():


### PR DESCRIPTION
Bugfix for 
```text
ValueError: ("could not convert string to float: 'Проблемы с запуском виртуальных машин в зоне ru-central1-a'", Metric(yc_last_incidents, Yandex Cloud Services last incidents, gauge, , [Sample(name='yc_last_incidents', labels={'service_name': 'compute', 'end_date': 'active'}, value='Проблемы с запуском виртуальных машин в зоне ru-central1-a', timestamp=None, exemplar=None)]))
```